### PR TITLE
Add withCopierRequestOptions and test

### DIFF
--- a/lib/copy.go
+++ b/lib/copy.go
@@ -3,6 +3,7 @@ package s3cp
 import (
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
@@ -46,8 +47,8 @@ type Copier struct {
 	// // SrcS3 is the source if set, it is a second region. Needed to delete.
 	// SrcS3 s3iface.S3API
 
-	// // RequestOptions to be passed to the individual calls.
-	// RequestOptions []request.Option
+	// RequestOptions to be passed to the individual calls.
+	RequestOptions []request.Option
 }
 
 // NewCopier creates a new Copier instance to copy opbjects concurrently from
@@ -65,4 +66,11 @@ func NewCopier(api API, opts ...func(*Copier)) *Copier {
 	}
 
 	return c
+}
+
+// WithCopierRequestOptions appends to the Copier's API requst options.
+func WithCopierRequestOptions(opts ...request.Option) func(*Copier) {
+	return func(c *Copier) {
+		c.RequestOptions = append(c.RequestOptions, opts...)
+	}
 }

--- a/lib/copy_test.go
+++ b/lib/copy_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/s3"
 
 	"github.com/reedobrien/checkers"
@@ -30,6 +31,18 @@ func TestNewWithOptions(t *testing.T) {
 	checkers.Equals(t, got.PartSize, int64(100))
 	checkers.Equals(t, got.Concurrency, 8)
 	checkers.Equals(t, got.Timeout, time.Second)
+}
+
+func TestWithCopierRequestOptions(t *testing.T) {
+	api := newDummyAPI(nil, nil)
+	tut := s3cp.NewCopier(api)
+
+	s3cp.WithCopierRequestOptions(
+		func(r *request.Request) { r.RetryCount = 99 },
+		func(r *request.Request) { r.DisableFollowRedirects = true },
+	)(tut)
+
+	checkers.Equals(t, len(tut.RequestOptions), 2)
 }
 
 func newDummyAPI(coo *s3.CopyObjectOutput, err error) *dummyAPI {


### PR DESCRIPTION
Allow passing in aws/request.Request options, which can be used on each
call in the copy implementation.