### PR TITLE
Add type to handle converting input to part input

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
     build:
         docker:
-            - image: circleci/golang:1.9
+            - image: circleci/golang:1.10rc1
         working_directory: /go/src/github.com/reedobrien/s3cp
 
         environment:

--- a/lib/dummy/dummy.go
+++ b/lib/dummy/dummy.go
@@ -1,0 +1,81 @@
+package dummy
+
+import (
+	"sync/atomic"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// NewS3API mocks the S3 API parts we use.
+func NewS3API(region string, opts ...func(*S3API)) *S3API {
+	if region == "" {
+		region = "default-region"
+	}
+
+	d := &S3API{region: aws.String(region)}
+
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
+}
+
+// S3API is the API struct.
+type S3API struct {
+	region *string
+
+	Cmp      *s3.CreateMultipartUploadOutput
+	CmpCalls int64
+	CmpErr   error
+	CooErr   error
+	Coo      *s3.CopyObjectOutput
+	Hoo      *s3.HeadObjectOutput
+	HooErr   error
+	Doo      *s3.DeleteObjectOutput
+	DooCalls int64
+	DooErr   error
+}
+
+// CopyObjectWithContext is a mock method.
+func (d *S3API) CopyObjectWithContext(_ aws.Context, in *s3.CopyObjectInput, opts ...request.Option) (*s3.CopyObjectOutput, error) {
+	if d.CooErr != nil {
+		return nil, d.CooErr
+	}
+	return d.Coo, nil
+}
+
+// CreateMultipartUploadWithContext is a mock method.
+func (d *S3API) CreateMultipartUploadWithContext(_ aws.Context, in *s3.CreateMultipartUploadInput, ops ...request.Option) (*s3.CreateMultipartUploadOutput, error) {
+	_ = atomic.AddInt64(&d.CmpCalls, 1)
+	if d.CmpErr != nil {
+		return nil, d.CmpErr
+	}
+	return d.Cmp, nil
+}
+
+// HeadObjectWithContext is a mock method.
+func (d *S3API) HeadObjectWithContext(ctx aws.Context, in *s3.HeadObjectInput, opts ...request.Option) (*s3.HeadObjectOutput, error) {
+	if d.HooErr != nil {
+		return nil, d.HooErr
+	}
+	return d.Hoo, nil
+}
+
+// DeleteObjectWithContext is a mock method.
+func (d *S3API) DeleteObjectWithContext(ctx aws.Context, in *s3.DeleteObjectInput, opts ...request.Option) (*s3.DeleteObjectOutput, error) {
+	_ = atomic.AddInt64(&d.DooCalls, 1)
+	if d.DooErr != nil {
+		return nil, d.DooErr
+	}
+	return d.Doo, nil
+}
+
+// Region is a mock method.
+func (d *S3API) Region() string {
+	if d.region == nil {
+		return ""
+	}
+	return *d.region
+}

--- a/lib/types.go
+++ b/lib/types.go
@@ -1,0 +1,44 @@
+package s3cp
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+type copyPartResult struct {
+	Part int64
+	*s3.CopyPartResult
+}
+
+type multipartCopyInput struct {
+	PartNumber      int64
+	CopySourceRange *string
+	UploadID        *string
+}
+
+func (m multipartCopyInput) FromCopyPartInput(c *s3.CopyObjectInput) *s3.UploadPartCopyInput {
+	return &s3.UploadPartCopyInput{
+		PartNumber:      aws.Int64(m.PartNumber),
+		CopySourceRange: m.CopySourceRange,
+		UploadId:        m.UploadID,
+
+		Bucket: c.Bucket,
+
+		CopySource:                     c.CopySource,
+		CopySourceIfMatch:              c.CopySourceIfMatch,
+		CopySourceIfModifiedSince:      c.CopySourceIfModifiedSince,
+		CopySourceIfNoneMatch:          c.CopySourceIfNoneMatch,
+		CopySourceIfUnmodifiedSince:    c.CopySourceIfUnmodifiedSince,
+		CopySourceSSECustomerAlgorithm: c.CopySourceSSECustomerAlgorithm,
+		CopySourceSSECustomerKey:       c.CopySourceSSECustomerKey,
+		CopySourceSSECustomerKeyMD5:    c.CopySourceSSECustomerKeyMD5,
+
+		Key: c.Key,
+
+		RequestPayer: c.RequestPayer,
+
+		SSECustomerAlgorithm: c.SSECustomerAlgorithm,
+		SSECustomerKey:       c.SSECustomerKey,
+		SSECustomerKeyMD5:    c.SSECustomerKeyMD5,
+	}
+}


### PR DESCRIPTION
Adds a type which will take the s3.CopyObjectInput and generate an
s3.UploadPartCopyInput for multipart uploads. Additionally, refactored
the dummy bits that are shared into a dummy package.

The beginning of copyParts is also in this, but need the UPCI bits for
it...