### PR TITLE
Add copyParts and some tests

### DIFF
--- a/lib/dummy/dummy.go
+++ b/lib/dummy/dummy.go
@@ -36,6 +36,9 @@ type S3API struct {
 	Doo      *s3.DeleteObjectOutput
 	DooCalls int64
 	DooErr   error
+	Upc      *s3.UploadPartCopyOutput
+	UpcErr   error
+	UpcCalls int64
 }
 
 // CopyObjectWithContext is a mock method.
@@ -70,6 +73,15 @@ func (d *S3API) DeleteObjectWithContext(ctx aws.Context, in *s3.DeleteObjectInpu
 		return nil, d.DooErr
 	}
 	return d.Doo, nil
+}
+
+// UploadPartCopyWithContext is a mock method.
+func (d *S3API) UploadPartCopyWithContext(ctx aws.Context, in *s3.UploadPartCopyInput, opts ...request.Option) (*s3.UploadPartCopyOutput, error) {
+	_ = atomic.AddInt64(&d.UpcCalls, 1)
+	if d.UpcErr != nil {
+		return nil, d.UpcErr
+	}
+	return d.Upc, nil
 }
 
 // Region is a mock method.

--- a/lib/dummy/logger.go
+++ b/lib/dummy/logger.go
@@ -1,0 +1,35 @@
+package dummy
+
+import (
+	"log"
+	"os"
+)
+
+// NewLogOutput returns a constructed SafeLogOuput and sets log output to it.
+func NewLogOutput(out chan string) *SafeLogOutput {
+	slo := &SafeLogOutput{
+		done: make(chan struct{}),
+		out:  out,
+	}
+	log.SetOutput(slo)
+	return slo
+}
+
+// SafeLogOutput is a goroutine safe buffer for capturing
+// log output.
+type SafeLogOutput struct {
+	done chan struct{}
+	out  chan string
+}
+
+// Write writes the bytes to the buffer while locked.
+func (s *SafeLogOutput) Write(p []byte) (int, error) {
+	s.out <- string(p)
+	return len(p), nil
+}
+
+// Reset returns the log output to stderr
+func (s *SafeLogOutput) Reset() {
+	log.SetOutput(os.Stderr)
+	close(s.out)
+}

--- a/lib/types.go
+++ b/lib/types.go
@@ -6,7 +6,7 @@ import (
 )
 
 type copyPartResult struct {
-	Part int64
+	PartNumber int64
 	*s3.CopyPartResult
 }
 


### PR DESCRIPTION
Create a concurrency safe log capturer and use it in tests that log
concurrently. Convert existing tests to use logger.